### PR TITLE
Fix broken navigation in settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:password_vault_app/screens/login_screen.dart';
 import 'package:password_vault_app/screens/vault_screen.dart';
 import 'package:password_vault_app/screens/register_screen.dart';
+import 'package:password_vault_app/screens/settings_screen.dart';
 
 void main() {
   runApp(MyApp());
@@ -18,6 +19,7 @@ class MyApp extends StatelessWidget {
         '/': (context) => LoginScreen(),
         '/vault': (context) => VaultScreen(),
         '/register': (context) => RegisterScreen(),
+        '/settings': (context) => SettingsScreen(),
       },
     );
   }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:local_auth/local_auth.dart';
-import 'package:password_vault_app/screens/register_screen.dart'; // Import RegisterScreen
 
 class LoginScreen extends StatefulWidget {
   @override
@@ -92,9 +91,7 @@ class _LoginScreenState extends State<LoginScreen> {
             ),
             TextButton(
               onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(builder: (context) => RegisterScreen()),
-                );
+                Navigator.of(context).pushNamed('/register');
               },
               child: Text("Don't have an account? Register here"),
             ),

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -54,7 +54,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
           content: Text("User registered successfully with biometrics!"),
         ));
 
-        Navigator.of(context).pop(); // Return to the login screen after registration
+        Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false); // Return to the login screen after registration
       } else {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text("Biometric registration failed"),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsScreen extends StatefulWidget {
+  @override
+  _SettingsScreenState createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  final FlutterSecureStorage secureStorage = FlutterSecureStorage();
+  bool _autoLockEnabled = true;
+  int _autoLockTimeout = 5; // minutes
+  bool _clipboardClearEnabled = true;
+  int _clipboardClearTimeout = 50; // seconds
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _autoLockEnabled = prefs.getBool('auto_lock_enabled') ?? true;
+      _autoLockTimeout = prefs.getInt('auto_lock_timeout') ?? 5;
+      _clipboardClearEnabled = prefs.getBool('clipboard_clear_enabled') ?? true;
+      _clipboardClearTimeout = prefs.getInt('clipboard_clear_timeout') ?? 50;
+    });
+  }
+
+  Future<void> _saveSettings() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('auto_lock_enabled', _autoLockEnabled);
+    await prefs.setInt('auto_lock_timeout', _autoLockTimeout);
+    await prefs.setBool('clipboard_clear_enabled', _clipboardClearEnabled);
+    await prefs.setInt('clipboard_clear_timeout', _clipboardClearTimeout);
+  }
+
+  Future<void> _logout() async {
+    // Show confirmation dialog
+    bool? shouldLogout = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Logout'),
+        content: Text('Are you sure you want to logout?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text('Logout'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldLogout == true) {
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+    }
+  }
+
+  Future<void> _clearAllData() async {
+    bool? shouldClear = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Clear All Data'),
+        content: Text('This will delete all saved passwords. This action cannot be undone. Are you sure?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text('Clear All'),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldClear == true) {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+      await prefs.remove('passwords');
+      await secureStorage.deleteAll();
+      
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('All data cleared successfully')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Settings'),
+      ),
+      body: ListView(
+        padding: EdgeInsets.all(16.0),
+        children: [
+          Card(
+            child: Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Security Settings',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  SizedBox(height: 16),
+                  SwitchListTile(
+                    title: Text('Auto Lock'),
+                    subtitle: Text('Lock app when inactive'),
+                    value: _autoLockEnabled,
+                    onChanged: (value) {
+                      setState(() {
+                        _autoLockEnabled = value;
+                      });
+                      _saveSettings();
+                    },
+                  ),
+                  if (_autoLockEnabled) ...[
+                    Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('Auto Lock Timeout: $_autoLockTimeout minutes'),
+                          Slider(
+                            value: _autoLockTimeout.toDouble(),
+                            min: 1,
+                            max: 30,
+                            divisions: 29,
+                            label: '$_autoLockTimeout minutes',
+                            onChanged: (value) {
+                              setState(() {
+                                _autoLockTimeout = value.toInt();
+                              });
+                              _saveSettings();
+                            },
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                  SwitchListTile(
+                    title: Text('Auto Clear Clipboard'),
+                    subtitle: Text('Clear clipboard automatically for security'),
+                    value: _clipboardClearEnabled,
+                    onChanged: (value) {
+                      setState(() {
+                        _clipboardClearEnabled = value;
+                      });
+                      _saveSettings();
+                    },
+                  ),
+                  if (_clipboardClearEnabled) ...[
+                    Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('Clipboard Clear Timeout: $_clipboardClearTimeout seconds'),
+                          Slider(
+                            value: _clipboardClearTimeout.toDouble(),
+                            min: 10,
+                            max: 120,
+                            divisions: 11,
+                            label: '$_clipboardClearTimeout seconds',
+                            onChanged: (value) {
+                              setState(() {
+                                _clipboardClearTimeout = value.toInt();
+                              });
+                              _saveSettings();
+                            },
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          SizedBox(height: 16),
+          Card(
+            child: Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Data Management',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  SizedBox(height: 16),
+                  ListTile(
+                    leading: Icon(Icons.delete_forever, color: Colors.red),
+                    title: Text('Clear All Data'),
+                    subtitle: Text('Delete all saved passwords and settings'),
+                    onTap: _clearAllData,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SizedBox(height: 16),
+          Card(
+            child: Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Account',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  SizedBox(height: 16),
+                  ListTile(
+                    leading: Icon(Icons.logout),
+                    title: Text('Logout'),
+                    subtitle: Text('Sign out of your account'),
+                    onTap: _logout,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/vault_screen.dart
+++ b/lib/screens/vault_screen.dart
@@ -223,6 +223,30 @@ class _VaultScreenState extends State<VaultScreen> with SingleTickerProviderStat
     ).then((value) => value ?? false); // Return false if dialog is dismissed
   }
 
+  Future<void> _showLogoutDialog() async {
+    bool? shouldLogout = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Logout'),
+        content: Text('Are you sure you want to logout?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text('Logout'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldLogout == true) {
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return WillPopScope(
@@ -232,6 +256,42 @@ class _VaultScreenState extends State<VaultScreen> with SingleTickerProviderStat
       child: Scaffold(
         appBar: AppBar(
           title: Text("Password Vault"),
+          actions: [
+            PopupMenuButton<String>(
+              onSelected: (value) {
+                switch (value) {
+                  case 'settings':
+                    Navigator.of(context).pushNamed('/settings');
+                    break;
+                  case 'logout':
+                    _showLogoutDialog();
+                    break;
+                }
+              },
+              itemBuilder: (BuildContext context) => [
+                PopupMenuItem<String>(
+                  value: 'settings',
+                  child: Row(
+                    children: [
+                      Icon(Icons.settings),
+                      SizedBox(width: 8),
+                      Text('Settings'),
+                    ],
+                  ),
+                ),
+                PopupMenuItem<String>(
+                  value: 'logout',
+                  child: Row(
+                    children: [
+                      Icon(Icons.logout),
+                      SizedBox(width: 8),
+                      Text('Logout'),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
           bottom: TabBar(
             controller: _tabController,
             tabs: [


### PR DESCRIPTION
Add a new settings screen and refactor app navigation for consistency and functionality.

The user reported that "navigation to settings and other does not work". This PR addresses several underlying issues: a dedicated settings screen was missing, the vault screen had no UI elements to navigate to other sections (like settings or logout), and navigation between login/register and vault screens was inconsistent (mixing `MaterialPageRoute` with named routes). This PR introduces the `SettingsScreen`, adds a navigation menu to the `VaultScreen`, and standardizes all navigation to use named routes, providing a complete and functional navigation system.

---
<a href="https://cursor.com/background-agent?bcId=bc-5681dc79-7c47-476e-9ec4-58626746db1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5681dc79-7c47-476e-9ec4-58626746db1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>